### PR TITLE
Update README to match to new ObjTree definiton without XML

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Initialize and return a new XML.ObjTree object.
 
 __Example:__
 
-    xotree = new XML.ObjTree()
+    xotree = new ObjTree()
 
 <a name="parseXML" />
 ### parseXML(xml)


### PR DESCRIPTION
It seems this version removed XML and just uses ObjTree, so the README should be updated to inform the user about how to use it correctly. Otherwise getting XML not found error.
